### PR TITLE
Split .locale function to the .locale and .mutableLocale

### DIFF
--- a/src/MomentRe.re
+++ b/src/MomentRe.re
@@ -304,7 +304,12 @@ module Moment = {
   [@bs.send.pipe: t] external defaultFormat: string = "format";
   [@bs.send.pipe: t] external utc: string => t = "utc";
   [@bs.send.pipe: t] external defaultUtc: t = "utc";
-  [@bs.send.pipe: t] external locale: string => t = "locale";
+  [@bs.send.pipe: t] external mutableLocale: string => t = "locale";
+  let locale = (locale, moment) => {
+    let clone = clone(moment);
+    mutableLocale(locale, clone);
+    clone;
+  };
   [@bs.send]
   external fromNow: (t, ~withoutSuffix: option(bool)) => string = "fromNow";
   [@bs.send]

--- a/src/__tests__/moment_test.re
+++ b/src/__tests__/moment_test.re
@@ -654,6 +654,14 @@ let () =
           expect(momentNow() |> Moment.defaultUtc |> Moment.isValid)
           |> toBe(true)
         );
+        test("#mutableLocale", () =>
+          expect(
+            moment("2018-01-01 00:00:00Z")
+            |> Moment.mutableLocale("da_DK")
+            |> Moment.format("MMMM Do YYYY"),
+          )
+          |> toBe("januar 1. 2018")
+        );
         test("#locale", () =>
           expect(
             moment("2018-01-01 00:00:00Z")
@@ -662,6 +670,14 @@ let () =
           )
           |> toBe("januar 1. 2018")
         );
+        test("#locale doesn't mutate input", () => {
+          let original = moment("2018-01-01 00:00:00Z");
+          original |> Moment.locale("da_DK")
+          expect(
+            original |> Moment.format("MMMM Do YYYY")
+          )
+          |> toBe("January 1st 2018")
+        });
         test(
           "#valueOf", /* TODO: float? */
           () =>


### PR DESCRIPTION
`locale` mutates input, I propose to split it to the `locale` and `mutableLocale` functions