### PR TITLE
Make mutableLocale return unit instead of t

### DIFF
--- a/src/MomentRe.re
+++ b/src/MomentRe.re
@@ -304,10 +304,10 @@ module Moment = {
   [@bs.send.pipe: t] external defaultFormat: string = "format";
   [@bs.send.pipe: t] external utc: string => t = "utc";
   [@bs.send.pipe: t] external defaultUtc: t = "utc";
-  [@bs.send.pipe: t] external mutableLocale: string => t = "locale";
+  [@bs.send.pipe: t] external mutableLocale: string => unit = "locale";
   let locale = (locale, moment) => {
     let clone = clone(moment);
-    mutableLocale(locale, clone)->ignore;
+    mutableLocale(locale, clone);
     clone;
   };
   [@bs.send]

--- a/src/MomentRe.re
+++ b/src/MomentRe.re
@@ -307,7 +307,7 @@ module Moment = {
   [@bs.send.pipe: t] external mutableLocale: string => t = "locale";
   let locale = (locale, moment) => {
     let clone = clone(moment);
-    mutableLocale(locale, clone);
+    mutableLocale(locale, clone)->ignore;
     clone;
   };
   [@bs.send]

--- a/src/__tests__/moment_test.re
+++ b/src/__tests__/moment_test.re
@@ -654,14 +654,14 @@ let () =
           expect(momentNow() |> Moment.defaultUtc |> Moment.isValid)
           |> toBe(true)
         );
-        test("#mutableLocale", () =>
+        test("#mutableLocale", () => {
+          let original = moment("2018-01-01 00:00:00Z");
+          original |> Moment.mutableLocale("da_DK");
           expect(
-            moment("2018-01-01 00:00:00Z")
-            |> Moment.mutableLocale("da_DK")
-            |> Moment.format("MMMM Do YYYY"),
+            original |> Moment.format("MMMM Do YYYY")
           )
           |> toBe("januar 1. 2018")
-        );
+        });
         test("#locale", () =>
           expect(
             moment("2018-01-01 00:00:00Z")
@@ -672,7 +672,7 @@ let () =
         );
         test("#locale doesn't mutate input", () => {
           let original = moment("2018-01-01 00:00:00Z");
-          original |> Moment.locale("da_DK")
+          original |> Moment.locale("da_DK") |> ignore;
           expect(
             original |> Moment.format("MMMM Do YYYY")
           )


### PR DESCRIPTION
This is required to fix building error:
```
# File "src/MomentRe.re", line 310, characters 4-32:
# 310 |     mutableLocale(locale, clone);
#           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: This expression has type t but an expression was expected of type
#        unit because it is in the left-hand side of a sequence
```